### PR TITLE
Support for specifying the API version and paging through collections

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const {
   validateParams
 } = require('./src/utilities.js')
 
-const request = require('./src/request.js')
+const { request, Page } = require('./src/request.js')
 
 class Registers {
   constructor (name, { version } = {}) {
@@ -106,7 +106,7 @@ class Registers {
         this._getEndpoint(`blobs/${blobHashOrParams}`)
       )
     } else {
-      return request(
+      return Page.request(
         this._getEndpoint(`blobs`)
       )
     }

--- a/index.test.js
+++ b/index.test.js
@@ -104,6 +104,15 @@ describe('Registers', () => {
       expect(Object.keys(result).length).toBe(4)
       expect(result).toEqual(fixture)
     })
+    it('queries the requested API version', async () => {
+      const register = new Registers('register', { version: 'next' })
+      await register.records()
+      expect(fetch).toHaveBeenCalledWith('https://register.register.gov.uk/next/records', {
+        headers: {
+          'Accept': 'application/json'
+        }
+      })
+    })
   })
   describe('entries', () => {
     it('returns json with defaults set', async () => {
@@ -120,6 +129,15 @@ describe('Registers', () => {
       })
       expect(Object.keys(result).length).toBe(66)
       expect(result).toEqual(fixture)
+    })
+    it('queries the requested API version', async () => {
+      const register = new Registers('register', { version: 'next' })
+      await register.entries()
+      expect(fetch).toHaveBeenCalledWith('https://register.register.gov.uk/next/entries', {
+        headers: {
+          'Accept': 'application/json'
+        }
+      })
     })
     it('params start and limit can be set', async () => {
       const register = new Registers('register')
@@ -162,6 +180,39 @@ describe('Registers', () => {
       })
       expect(Object.keys(result).length).toBe(5)
       expect(result).toEqual(fixture)
+    })
+    it('uses /blobs for v2', async () => {
+      const register = new Registers('register', { version: 'next' })
+      await register.items('1220610bde42d3ae2ed3dd829263fe461542742a10ca33865d96d31ae043b242c300')
+      expect(fetch).toHaveBeenCalledWith('https://register.register.gov.uk/next/blobs/1220610bde42d3ae2ed3dd829263fe461542742a10ca33865d96d31ae043b242c300', {
+        headers: {
+          'Accept': 'application/json'
+        }
+      })
+    })
+  })
+  describe('blobs', () => {
+    it('fetches a page of blobs', async () => {
+      const register = new Registers('register', { version: 'next' })
+      await register.blobs()
+      expect(fetch).toHaveBeenCalledWith('https://register.register.gov.uk/next/blobs', {
+        headers: {
+          'Accept': 'application/json'
+        }
+      })
+    })
+    it('fetches a single blob', async () => {
+      const register = new Registers('register', { version: 'next' })
+      await register.blobs('1220610bde42d3ae2ed3dd829263fe461542742a10ca33865d96d31ae043b242c300')
+      expect(fetch).toHaveBeenCalledWith('https://register.register.gov.uk/next/blobs/1220610bde42d3ae2ed3dd829263fe461542742a10ca33865d96d31ae043b242c300', {
+        headers: {
+          'Accept': 'application/json'
+        }
+      })
+    })
+    it('is unavailable in v1', async () => {
+      const register = new Registers('register')
+      expect(() => { register.blobs() }).toThrowError(Error)
     })
   })
   describe('download-register', () => {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "node": ">= 6.0.0"
   },
   "dependencies": {
+    "http-link-header": "^1.0.2",
     "node-fetch": "^2.2.0"
   },
   "devDependencies": {

--- a/src/request.js
+++ b/src/request.js
@@ -1,5 +1,5 @@
 const fetch = require('node-fetch')
-
+const LinkHeader = require('http-link-header')
 const getBuffer = require('./get-buffer-response.js')
 
 function request (url, type = 'json') {
@@ -18,4 +18,48 @@ function request (url, type = 'json') {
   })
 }
 
-module.exports = request
+class Page {
+  constructor (items, nextUrl) {
+    this.items = items
+    this._nextUrl = nextUrl
+  }
+
+  next () {
+    if (this._nextUrl === null) {
+      return null
+    }
+
+    return Page.request(this._nextUrl)
+  }
+
+  static async request (url) {
+    const response = await fetch(url, {
+      headers: {
+        'Accept': `application/json`
+      }
+    })
+    const items = await response.json()
+    const headers = response.headers
+    const nextUrl = this._extractNextUrl(headers, response.url)
+
+    return new Page(items, nextUrl)
+  }
+
+  static _extractNextUrl (headers, baseUrl) {
+    const links = headers.get('Link')
+    if (links === null) {
+      return null
+    }
+
+    const parsedLinks = LinkHeader.parse(links)
+    if (!parsedLinks.has('rel', 'next')) {
+      return null
+    }
+
+    const nextUrlRelative = parsedLinks.get('rel', 'next')[0].uri
+
+    return new URL(nextUrlRelative, baseUrl).href
+  }
+}
+
+module.exports = { request, Page }

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1683,6 +1683,2158 @@ module.exports = {
       ],
       register: 'country'
     },
-    'download-register': 'blob'
+    'download-register': 'blob',
+    'next/records': [
+      {
+        'text': 'Types of school in England',
+        'phase': 'beta',
+        'fields': [
+          'school-type-eng',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'school-type-eng',
+        'registry': 'department-for-education',
+        '_id': 'school-type-eng'
+      },
+      {
+        'text': 'A register of further education colleges across the United Kingdom',
+        'phase': 'beta',
+        'fields': [
+          'further-education-college-uk',
+          'name',
+          'region',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'further-education-college-uk',
+        'registry': 'department-for-international-trade',
+        '_id': 'further-education-college-uk'
+      },
+      {
+        'text': 'A register of the regions in the United Kingdom, where a further education college is situated',
+        'phase': 'beta',
+        'fields': [
+          'further-education-college-region-uk',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'further-education-college-region-uk',
+        'registry': 'department-for-international-trade',
+        '_id': 'further-education-college-region-uk'
+      },
+      {
+        'text': 'Specified persons for the information sharing agreements under the public service delivery, debt, fraud and civil registration provisions within the Digital Economy Act 2017',
+        'phase': 'beta',
+        'fields': [
+          'information-sharing-agreement-specified-person-0001',
+          'name',
+          'relevant-powers',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'information-sharing-agreement-specified-person-0001',
+        'registry': 'department-for-digital-culture-media-sport',
+        '_id': 'information-sharing-agreement-specified-person-0001'
+      },
+      {
+        'text': 'List of information sharing powers and objectives available under chapters 1, 2, 3 and 4 of Part 5 of the Digital Economy Act 2017',
+        'phase': 'beta',
+        'fields': [
+          'information-sharing-agreement-powers-and-objectives-0001',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'information-sharing-agreement-powers-and-objectives-0001',
+        'registry': 'department-for-digital-culture-media-sport',
+        '_id': 'information-sharing-agreement-powers-and-objectives-0001'
+      },
+      {
+        'text': 'Information sharing agreements under the public service delivery, debt, fraud and civil registration provisions within the Digital Economy Act 2017',
+        'phase': 'beta',
+        'fields': [
+          'information-sharing-agreement-0001',
+          'name',
+          'purpose',
+          'information-sharing-benefits',
+          'legal-power-disclosure',
+          'disclosed-information',
+          'controllers',
+          'controller-names',
+          'information-sharing-method',
+          'processors',
+          'processor-names',
+          'retention-period',
+          'start-date',
+          'end-date',
+          'review-date',
+          'contact',
+          'areas',
+          'area-names'
+        ],
+        'register': 'information-sharing-agreement-0001',
+        'registry': 'department-for-digital-culture-media-sport',
+        '_id': 'information-sharing-agreement-0001'
+      },
+      {
+        'text': 'The roles in the Digital, Data and Technology Profession Capability Framework and detailed descriptions of the types and level of skills expected for each role',
+        'phase': 'beta',
+        'fields': [
+          'ddat-profession-capability-framework',
+          'profession-capability-framework-skill-type',
+          'profession-capability-framework-job-family',
+          'profession-capability-framework-role',
+          'profession-capability-framework-role-level',
+          'profession-capability-framework-skill',
+          'profession-capability-framework-level',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework',
+        'registry': 'government-digital-service',
+        '_id': 'ddat-profession-capability-framework'
+      },
+      {
+        'text': 'Skills for use in the Digital, Data and Technology Profession Capability Framework',
+        'phase': 'beta',
+        'fields': [
+          'ddat-profession-capability-framework-skill',
+          'name',
+          'description',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-skill',
+        'registry': 'government-digital-service',
+        '_id': 'ddat-profession-capability-framework-skill'
+      },
+      {
+        'text': 'Types of skill for use in the Digital, Data and Technology Profession Capability Framework',
+        'phase': 'beta',
+        'fields': [
+          'ddat-profession-capability-framework-skill-type',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-skill-type',
+        'registry': 'government-digital-service',
+        '_id': 'ddat-profession-capability-framework-skill-type'
+      },
+      {
+        'text': 'The skills, levels, and appropriate descriptions used in the Digital Data and Technology Profession Capability Framework',
+        'phase': 'beta',
+        'fields': [
+          'ddat-profession-capability-framework-skill-level',
+          'profession-capability-framework-skill',
+          'profession-capability-framework-level',
+          'description',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-skill-level',
+        'registry': 'government-digital-service',
+        '_id': 'ddat-profession-capability-framework-skill-level'
+      },
+      {
+        'text': 'Roles defined for use in the Digital, Data and Technology Profession Capability Framework',
+        'phase': 'beta',
+        'fields': [
+          'ddat-profession-capability-framework-role',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-role',
+        'registry': 'government-digital-service',
+        '_id': 'ddat-profession-capability-framework-role'
+      },
+      {
+        'text': 'Levels associated with each role within the Digital, Data and Technology Profession Capability Framework',
+        'phase': 'beta',
+        'fields': [
+          'ddat-profession-capability-framework-role-level',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-role-level',
+        'registry': 'government-digital-service',
+        '_id': 'ddat-profession-capability-framework-role-level'
+      },
+      {
+        'text': 'Levels of competency for each Digital, Data and Technology Profession Capability Framework skill',
+        'phase': 'beta',
+        'fields': [
+          'ddat-profession-capability-framework-level',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-level',
+        'registry': 'government-digital-service',
+        '_id': 'ddat-profession-capability-framework-level'
+      },
+      {
+        'text': 'Job families for use in the Digital, Data and Technology Profession Capability Framework',
+        'phase': 'beta',
+        'fields': [
+          'ddat-profession-capability-framework-job-family',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-job-family',
+        'registry': 'government-digital-service',
+        '_id': 'ddat-profession-capability-framework-job-family'
+      },
+      {
+        'text': 'Open standards approved for use in government technology',
+        'phase': 'beta',
+        'fields': [
+          'approved-open-standard',
+          'name',
+          'short-name',
+          'website',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'approved-open-standard',
+        'registry': 'government-digital-service',
+        '_id': 'approved-open-standard'
+      },
+      {
+        'text': 'Guidance defining open standards approved for government technology',
+        'phase': 'beta',
+        'fields': [
+          'approved-open-standard-guidance',
+          'name',
+          'approved-open-standards',
+          'website',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'approved-open-standard-guidance',
+        'registry': 'government-digital-service',
+        '_id': 'approved-open-standard-guidance'
+      },
+      {
+        'text': 'British English names and descriptive terms for political, administrative and geographical entities that are not recognised as countries by the UK government',
+        'phase': 'beta',
+        'fields': [
+          'territory',
+          'name',
+          'official-name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'territory',
+        'registry': 'foreign-commonwealth-office',
+        '_id': 'territory'
+      },
+      {
+        'text': 'Types of qualifications regulated by Ofqual',
+        'phase': 'beta',
+        'fields': [
+          'qualification-type',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'qualification-type',
+        'registry': 'ofqual',
+        '_id': 'qualification-type'
+      },
+      {
+        'text': 'Groups of jobcentre offices in England, Scotland and Wales',
+        'phase': 'beta',
+        'fields': [
+          'jobcentre-group',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'jobcentre-group',
+        'registry': 'department-for-work-pensions',
+        '_id': 'jobcentre-group'
+      },
+      {
+        'text': 'Districts of jobcentre offices in England, Scotland and Wales',
+        'phase': 'beta',
+        'fields': [
+          'jobcentre-district',
+          'name',
+          'jobcentre-group',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'jobcentre-district',
+        'registry': 'department-for-work-pensions',
+        '_id': 'jobcentre-district'
+      },
+      {
+        'text': 'Government services that have a government service domain on GOV.UK',
+        'phase': 'beta',
+        'fields': [
+          'government-service',
+          'hostname',
+          'government-organisation',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'government-service',
+        'registry': 'government-digital-service',
+        '_id': 'government-service'
+      },
+      {
+        'text': 'Government departments, agencies or teams that exist on GOV.UK',
+        'phase': 'beta',
+        'fields': [
+          'government-organisation',
+          'name',
+          'website',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'government-organisation',
+        'registry': 'government-digital-service',
+        '_id': 'government-organisation'
+      },
+      {
+        'text': 'Government domains that appear on GOV.UK',
+        'phase': 'beta',
+        'fields': [
+          'government-domain',
+          'hostname',
+          'organisation',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'government-domain',
+        'registry': 'cabinet-office',
+        '_id': 'government-domain'
+      },
+      {
+        'text': 'British English names and descriptive terms for countries as recognised by the UK government',
+        'phase': 'beta',
+        'fields': [
+          'country',
+          'name',
+          'official-name',
+          'citizen-names',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'country',
+        'registry': 'foreign-commonwealth-office',
+        '_id': 'country'
+      },
+      {
+        'text': 'Food allergens as recognised by the Food Standards Agency',
+        'phase': 'beta',
+        'fields': [
+          'allergen',
+          'name',
+          'allergen-group',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'allergen',
+        'registry': 'food-standards-agency',
+        '_id': 'allergen'
+      },
+      {
+        'text': 'Subjects of qualifications regulated by Ofqual',
+        'phase': 'beta',
+        'fields': [
+          'qualification-sector-subject-area',
+          'parent-qualification-sector-subject-area',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'qualification-sector-subject-area',
+        'registry': 'ofqual',
+        '_id': 'qualification-sector-subject-area'
+      },
+      {
+        'text': 'Levels of qualifications regulated by Ofqual',
+        'phase': 'beta',
+        'fields': [
+          'qualification-level',
+          'name',
+          'qualification-sub-level',
+          'european-qualification-framework-level',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'qualification-level',
+        'registry': 'ofqual',
+        '_id': 'qualification-level'
+      },
+      {
+        'text': 'Assessment methods of qualifications regulated by Ofqual',
+        'phase': 'beta',
+        'fields': [
+          'qualification-assessment-method',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'qualification-assessment-method',
+        'registry': 'ofqual',
+        '_id': 'qualification-assessment-method'
+      },
+      {
+        'text': 'Local authorities in England',
+        'phase': 'beta',
+        'fields': [
+          'local-authority-eng',
+          'local-authority-type',
+          'name',
+          'official-name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-eng',
+        'registry': 'ministry-of-housing-communities-and-local-government',
+        '_id': 'local-authority-eng'
+      },
+      {
+        'text': 'Types of local government organisations in the UK',
+        'phase': 'beta',
+        'fields': [
+          'local-authority-type',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-type',
+        'registry': 'ministry-of-housing-communities-and-local-government',
+        '_id': 'local-authority-type'
+      },
+      {
+        'text': 'Jobcentre offices in England, Scotland and Wales',
+        'phase': 'beta',
+        'fields': [
+          'jobcentre',
+          'name',
+          'jobcentre-district',
+          'address',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'jobcentre',
+        'registry': 'department-for-work-pensions',
+        '_id': 'jobcentre'
+      },
+      {
+        'text': 'Statistical geography data for local government districts in Northern Ireland',
+        'phase': 'beta',
+        'fields': [
+          'statistical-geography-local-government-district-nir',
+          'local-authority-nir',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-local-government-district-nir',
+        'registry': 'office-for-national-statistics',
+        '_id': 'statistical-geography-local-government-district-nir'
+      },
+      {
+        'text': 'Statistical geography data for a unitary authority in England',
+        'phase': 'beta',
+        'fields': [
+          'statistical-geography-unitary-authority-eng',
+          'local-authority-eng',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-unitary-authority-eng',
+        'registry': 'office-for-national-statistics',
+        '_id': 'statistical-geography-unitary-authority-eng'
+      },
+      {
+        'text': 'Statistical geography data for non-metropolitan councils in England',
+        'phase': 'beta',
+        'fields': [
+          'statistical-geography-non-metropolitan-district-eng',
+          'local-authority-eng',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-non-metropolitan-district-eng',
+        'registry': 'office-for-national-statistics',
+        '_id': 'statistical-geography-non-metropolitan-district-eng'
+      },
+      {
+        'text': 'Statistical geography data for registration districts in Wales',
+        'phase': 'beta',
+        'fields': [
+          'statistical-geography-registration-district-wls',
+          'registration-district',
+          'name',
+          'name-cy',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-registration-district-wls',
+        'registry': 'office-for-national-statistics',
+        '_id': 'statistical-geography-registration-district-wls'
+      },
+      {
+        'text': 'Statistical geography data for registration districts in England',
+        'phase': 'beta',
+        'fields': [
+          'statistical-geography-registration-district-eng',
+          'registration-district',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-registration-district-eng',
+        'registry': 'office-for-national-statistics',
+        '_id': 'statistical-geography-registration-district-eng'
+      },
+      {
+        'text': 'Statistical geography data for metropolitan councils in England',
+        'phase': 'beta',
+        'fields': [
+          'statistical-geography-metropolitan-district-eng',
+          'local-authority-eng',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-metropolitan-district-eng',
+        'registry': 'office-for-national-statistics',
+        '_id': 'statistical-geography-metropolitan-district-eng'
+      },
+      {
+        'text': 'Statistical geography data for London boroughs in England',
+        'phase': 'beta',
+        'fields': [
+          'statistical-geography-london-borough-eng',
+          'local-authority-eng',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-london-borough-eng',
+        'registry': 'office-for-national-statistics',
+        '_id': 'statistical-geography-london-borough-eng'
+      },
+      {
+        'text': 'Statistical geography data for counties in England',
+        'phase': 'beta',
+        'fields': [
+          'statistical-geography-county-eng',
+          'local-authority-eng',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-county-eng',
+        'registry': 'office-for-national-statistics',
+        '_id': 'statistical-geography-county-eng'
+      },
+      {
+        'text': 'Local authorities in Northern Ireland',
+        'phase': 'beta',
+        'fields': [
+          'local-authority-nir',
+          'local-authority-type',
+          'name',
+          'website',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-nir',
+        'registry': 'department-for-communities-northern-ireland',
+        '_id': 'local-authority-nir'
+      },
+      {
+        'text': 'Prison estates in England and Wales as defined by HM Prison and Probation Service',
+        'phase': 'beta',
+        'fields': [
+          'prison-estate',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'prison-estate',
+        'registry': 'ministry-of-justice',
+        '_id': 'prison-estate'
+      },
+      {
+        'text': 'Geographies that are used in compiling official statistics',
+        'phase': 'beta',
+        'fields': [
+          'statistical-geography',
+          'name',
+          'area',
+          'organisation',
+          'register',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography',
+        'registry': 'office-for-national-statistics',
+        '_id': 'statistical-geography'
+      },
+      {
+        'text': 'Statistical geography data for principal local authorities in Wales',
+        'phase': 'beta',
+        'fields': [
+          'statistical-geography-unitary-authority-wls',
+          'principal-local-authority',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-unitary-authority-wls',
+        'registry': 'office-for-national-statistics',
+        '_id': 'statistical-geography-unitary-authority-wls'
+      },
+      {
+        'text': 'Districts in England and Wales responsible for recording births, marriages, deaths or civil partnerships for the purpose of registration acts',
+        'phase': 'beta',
+        'fields': [
+          'registration-district',
+          'name',
+          'name-cy',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'registration-district',
+        'registry': 'hm-passport-office',
+        '_id': 'registration-district'
+      },
+      {
+        'text': 'Public bodies in England that manage drainage systems',
+        'phase': 'beta',
+        'fields': [
+          'internal-drainage-board',
+          'name',
+          'legislation',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'internal-drainage-board',
+        'registry': 'department-for-environment-food-rural-affairs',
+        '_id': 'internal-drainage-board'
+      },
+      {
+        'text': 'Forms that the data in a register field can take',
+        'phase': 'beta',
+        'fields': [
+          'datatype',
+          'phase',
+          'text'
+        ],
+        'register': 'datatype',
+        'registry': 'cabinet-office',
+        '_id': 'datatype'
+      },
+      {
+        'text': 'Registers maintained by the UK government',
+        'phase': 'beta',
+        'fields': [
+          'register',
+          'text',
+          'registry',
+          'phase',
+          'copyright',
+          'fields'
+        ],
+        'register': 'register',
+        'registry': 'cabinet-office',
+        '_id': 'register'
+      },
+      {
+        'text': 'Principal local authorities in Wales',
+        'phase': 'beta',
+        'fields': [
+          'principal-local-authority',
+          'name',
+          'name-cy',
+          'official-name',
+          'official-name-cy',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'principal-local-authority',
+        'registry': 'welsh-government',
+        '_id': 'principal-local-authority'
+      },
+      {
+        'text': 'Local authorities in Scotland',
+        'phase': 'beta',
+        'fields': [
+          'local-authority-sct',
+          'local-authority-type',
+          'name',
+          'official-name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-sct',
+        'registry': 'the-scottish-government',
+        '_id': 'local-authority-sct'
+      },
+      {
+        'text': 'Field names which may appear in a register',
+        'phase': 'beta',
+        'fields': [
+          'field',
+          'datatype',
+          'phase',
+          'register',
+          'cardinality',
+          'text'
+        ],
+        'register': 'field',
+        'registry': 'cabinet-office',
+        '_id': 'field'
+      }
+    ],
+    'next/entries': [
+      {
+        'entry-number': 1,
+        'entry-timestamp': '2016-08-04T14:45:41Z',
+        'key': 'register',
+        'blob-hash': 'sha-256:e8bd8b3a8994f47be1d57cb283053d6dc96e121007110a6e461ae3fee2870a13'
+      },
+      {
+        'entry-number': 2,
+        'entry-timestamp': '2016-08-04T14:45:41Z',
+        'key': 'country',
+        'blob-hash': 'sha-256:565f9321785c2cd8543ee262c5331ba84d9a454bc8c45c662c7a17afa2c0b942'
+      },
+      {
+        'entry-number': 3,
+        'entry-timestamp': '2016-08-04T14:45:41Z',
+        'key': 'datatype',
+        'blob-hash': 'sha-256:03e6b56cdec46ebab847686b44c08e1189194dc88ceeef0b79623e1ee13cb95a'
+      },
+      {
+        'entry-number': 4,
+        'entry-timestamp': '2016-08-04T14:45:41Z',
+        'key': 'field',
+        'blob-hash': 'sha-256:da939f5b786ed6850dd6d5ea90573d0c9775042cd390d6d9150c958e362834b8'
+      },
+      {
+        'entry-number': 5,
+        'entry-timestamp': '2016-10-21T15:20:42Z',
+        'key': 'local-authority-type',
+        'blob-hash': 'sha-256:19915f7d3322d236cad2b264485bfb7555608d35abab8309533c07fe10e6914f'
+      },
+      {
+        'entry-number': 6,
+        'entry-timestamp': '2016-10-21T15:20:42Z',
+        'key': 'local-authority-eng',
+        'blob-hash': 'sha-256:4f0788db532e2292ccfe9e8298c8a022348ee0fc15052dc6936d18e25a14e811'
+      },
+      {
+        'entry-number': 7,
+        'entry-timestamp': '2016-12-15T11:37:14Z',
+        'key': 'territory',
+        'blob-hash': 'sha-256:8b27e52f67cbf3e0cd744c090915eb4b50c88b0bcba9432f53958c09dfe21265'
+      },
+      {
+        'entry-number': 8,
+        'entry-timestamp': '2016-12-15T15:44:11Z',
+        'key': 'territory',
+        'blob-hash': 'sha-256:5137b714aa7e58085320136b5029783fa781fa78bfb3636200af29691dc9b0e5'
+      },
+      {
+        'entry-number': 9,
+        'entry-timestamp': '2017-03-06T12:41:06Z',
+        'key': 'local-authority-type',
+        'blob-hash': 'sha-256:ae9141950c1384d0b67e654d1ca54aedd8c9fec228f53abeaebed2058ce878e0'
+      },
+      {
+        'entry-number': 10,
+        'entry-timestamp': '2017-04-06T06:58:03Z',
+        'key': 'internal-drainage-board',
+        'blob-hash': 'sha-256:a95652224bd8a23667c1eaafea0d0857f9b7e21d7d2c798e426b8f726ed028dc'
+      },
+      {
+        'entry-number': 11,
+        'entry-timestamp': '2017-04-27T13:52:32Z',
+        'key': 'government-organisation',
+        'blob-hash': 'sha-256:268bdaea7d3490557c0d55be544f0d864032d7ad81ca1004b97df16d629dac2d'
+      },
+      {
+        'entry-number': 12,
+        'entry-timestamp': '2017-05-03T13:19:02Z',
+        'key': 'government-service',
+        'blob-hash': 'sha-256:789a70a4b1ca04df3a92059ad33b9996d049cd2eaceffcd08f8afc2d65499627'
+      },
+      {
+        'entry-number': 13,
+        'entry-timestamp': '2017-05-16T09:49:11Z',
+        'key': 'registration-district',
+        'blob-hash': 'sha-256:efd572c7278044ac427704eb18a9628bfd92bd3b97a88f0b5c1515e29f97576a'
+      },
+      {
+        'entry-number': 14,
+        'entry-timestamp': '2017-05-24T11:15:39Z',
+        'key': 'prison-estate',
+        'blob-hash': 'sha-256:44d87636a25dc28e8276d0ba95092469c2f282f823e36bef4df1e21d2b4ffdff'
+      },
+      {
+        'entry-number': 15,
+        'entry-timestamp': '2017-05-24T12:11:34Z',
+        'key': 'registration-district',
+        'blob-hash': 'sha-256:262aad99491d37e0d1e9ea3b6f4d3b946c08b55f1112faddc5e75345a8563c56'
+      },
+      {
+        'entry-number': 16,
+        'entry-timestamp': '2017-05-25T07:52:39Z',
+        'key': 'local-authority-sct',
+        'blob-hash': 'sha-256:e4f43a873da83dfc90485eb784fe41436780be988fb4167f73f992f99e909ec2'
+      },
+      {
+        'entry-number': 17,
+        'entry-timestamp': '2017-07-07T10:51:15Z',
+        'key': 'principal-local-authority',
+        'blob-hash': 'sha-256:6a94a8165a781f461a24febbd1a0da2c3d688348fd412be8bc10d3b807a44c5b'
+      },
+      {
+        'entry-number': 18,
+        'entry-timestamp': '2017-07-14T15:05:33Z',
+        'key': 'register',
+        'blob-hash': 'sha-256:4b95c3bce8a616a2bfcb3d9193828da005bbb69dea1c997cc5b82d167d2ca322'
+      },
+      {
+        'entry-number': 19,
+        'entry-timestamp': '2017-07-14T15:18:13Z',
+        'key': 'datatype',
+        'blob-hash': 'sha-256:6a7d233e3e6a14cc7f970e069841557f66e112f4279d37d7fdcd45c5139dcaf1'
+      },
+      {
+        'entry-number': 20,
+        'entry-timestamp': '2017-07-14T15:18:57Z',
+        'key': 'internal-drainage-board',
+        'blob-hash': 'sha-256:9ac0814a3e14ab23d06ddf97723423d97d4dab07c655c828e7e756cd2fe657f4'
+      },
+      {
+        'entry-number': 21,
+        'entry-timestamp': '2017-07-14T15:19:32Z',
+        'key': 'local-authority-type',
+        'blob-hash': 'sha-256:ae5d08f86cbe99f606fee1c2107e793876fcf7206f03aa16802db2136e28f366'
+      },
+      {
+        'entry-number': 22,
+        'entry-timestamp': '2017-07-14T15:20:32Z',
+        'key': 'prison-estate',
+        'blob-hash': 'sha-256:35b6f1b940ceb8e4e0406c428f2afcee16667d0977ff6f8c38de3d8d2c335f95'
+      },
+      {
+        'entry-number': 23,
+        'entry-timestamp': '2017-07-14T15:21:24Z',
+        'key': 'registration-district',
+        'blob-hash': 'sha-256:4d45d7cbaecf21087e5e1d8ec4f9a0f1e31f3caa06daac39cd3eafe4ba230e39'
+      },
+      {
+        'entry-number': 24,
+        'entry-timestamp': '2017-09-25T08:16:14Z',
+        'key': 'government-domain',
+        'blob-hash': 'sha-256:857cbadaa4dc58079c2483ff9f228d82accec5c03e20a593a77b852f5860aa03'
+      },
+      {
+        'entry-number': 25,
+        'entry-timestamp': '2017-09-25T08:17:15Z',
+        'key': 'statistical-geography-unitary-authority-wls',
+        'blob-hash': 'sha-256:1649e7cd7a328f4e76fe6500d374f19f2e1ee4d61a9b91d3a2569af3a7791248'
+      },
+      {
+        'entry-number': 26,
+        'entry-timestamp': '2017-09-25T08:17:40Z',
+        'key': 'statistical-geography',
+        'blob-hash': 'sha-256:95084028bc97816b75b62db26bd1d51c3197de62efdf59b58855515c1f1cd777'
+      },
+      {
+        'entry-number': 27,
+        'entry-timestamp': '2017-10-03T15:49:32Z',
+        'key': 'prison-estate',
+        'blob-hash': 'sha-256:1cb127ba64143d28aed2b70d14dad0b6e20d157d020fc18839af2900f5e4194b'
+      },
+      {
+        'entry-number': 28,
+        'entry-timestamp': '2017-12-07T13:31:48Z',
+        'key': 'local-authority-nir',
+        'blob-hash': 'sha-256:d7cbae1d5ea71367182b741aa4029b7f47f63e1a2b54703cdadb6576dff9ebd0'
+      },
+      {
+        'entry-number': 29,
+        'entry-timestamp': '2017-12-18T08:22:36Z',
+        'key': 'statistical-geography-county-eng',
+        'blob-hash': 'sha-256:34928f1065c69f6b453a494e4e4673be30ef58e7313a09352f81904300268a4a'
+      },
+      {
+        'entry-number': 30,
+        'entry-timestamp': '2017-12-18T08:22:57Z',
+        'key': 'statistical-geography-london-borough-eng',
+        'blob-hash': 'sha-256:66967eb8dc65ea566dfffcd1cfed5fc0d133f2a9e02ba6f36b09e644ba461a96'
+      },
+      {
+        'entry-number': 31,
+        'entry-timestamp': '2017-12-18T08:23:20Z',
+        'key': 'statistical-geography-metropolitan-district-eng',
+        'blob-hash': 'sha-256:226194d2a5af7da3bc6812cb560ece433a7b91c5f6c79a75a9acca30d74b388c'
+      },
+      {
+        'entry-number': 32,
+        'entry-timestamp': '2017-12-18T08:23:48Z',
+        'key': 'statistical-geography-registration-district-eng',
+        'blob-hash': 'sha-256:75018bd326d7bd6839f6a5274e64ece47bb60816b7180c163f86d1998171a953'
+      },
+      {
+        'entry-number': 33,
+        'entry-timestamp': '2017-12-18T08:24:12Z',
+        'key': 'statistical-geography-registration-district-wls',
+        'blob-hash': 'sha-256:f45870303e8b513d91ed07fb81f918383b8f9a17e7d485d0a4c00bbf014bbece'
+      },
+      {
+        'entry-number': 34,
+        'entry-timestamp': '2017-12-18T08:24:34Z',
+        'key': 'statistical-geography-non-metropolitan-district-eng',
+        'blob-hash': 'sha-256:dd199bbe96e68d7a219ca84056164ccd0b5a814cfcaea2163307511ea7b9686b'
+      },
+      {
+        'entry-number': 35,
+        'entry-timestamp': '2017-12-18T08:25:02Z',
+        'key': 'statistical-geography-unitary-authority-eng',
+        'blob-hash': 'sha-256:fff32a5756b5a1159fe099cf9db4dcff7f7c965a04fd8677cb13c2580073c735'
+      },
+      {
+        'entry-number': 36,
+        'entry-timestamp': '2017-12-20T10:01:36Z',
+        'key': 'allergen',
+        'blob-hash': 'sha-256:ee54eb7eb0db89f695440e3f67d6b349eb6df891837c2ca98915ffa0383f5dff'
+      },
+      {
+        'entry-number': 37,
+        'entry-timestamp': '2018-02-15T09:59:38Z',
+        'key': 'statistical-geography-local-government-district-nir',
+        'blob-hash': 'sha-256:36840b2f05f0eae63ed8d389bd7b6985883a33f94aed28e85f295fe2808f3156'
+      },
+      {
+        'entry-number': 38,
+        'entry-timestamp': '2018-02-20T08:50:23Z',
+        'key': 'jobcentre',
+        'blob-hash': 'sha-256:16d92db6a458b523bfacd2245b596f12a22782980ea266e039c094c14cc5ae6f'
+      },
+      {
+        'entry-number': 39,
+        'entry-timestamp': '2018-02-20T08:50:51Z',
+        'key': 'jobcentre-district',
+        'blob-hash': 'sha-256:7c89f9f4e46e34502b1a1c1df3f6479101114a2af316affc64c7532e1af100e4'
+      },
+      {
+        'entry-number': 40,
+        'entry-timestamp': '2018-02-20T08:51:09Z',
+        'key': 'jobcentre-group',
+        'blob-hash': 'sha-256:731ad531996a5ef7e99f2c208843a27711412d3cba0fb007c663077366f7619b'
+      },
+      {
+        'entry-number': 41,
+        'entry-timestamp': '2018-02-20T12:34:00Z',
+        'key': 'local-authority-type',
+        'blob-hash': 'sha-256:f5e71ac52548df5270526ca97c870cdf4bc76502d33b2671d3d9528c305075e7'
+      },
+      {
+        'entry-number': 42,
+        'entry-timestamp': '2018-02-20T12:35:00Z',
+        'key': 'local-authority-eng',
+        'blob-hash': 'sha-256:7b2492ee43b1e0c054b9bc0cadcd138b4433d1cf953293df961be9eab04669f3'
+      },
+      {
+        'entry-number': 43,
+        'entry-timestamp': '2018-02-23T12:39:25Z',
+        'key': 'qualification-assessment-method',
+        'blob-hash': 'sha-256:0106fb5cc2e0881f746811d1bc16e0e5539c21dd3935c27f8d3b6fdaefb24fee'
+      },
+      {
+        'entry-number': 44,
+        'entry-timestamp': '2018-02-23T12:40:01Z',
+        'key': 'qualification-level',
+        'blob-hash': 'sha-256:8b654106f5187772e55edc32337c18e0e74a939947ee93255d698acf93b4873c'
+      },
+      {
+        'entry-number': 45,
+        'entry-timestamp': '2018-02-23T12:40:25Z',
+        'key': 'qualification-sector-subject-area',
+        'blob-hash': 'sha-256:5b312eb573c1a83defc3bd3c907925c0f28db59f40d0969fc30edb565787beff'
+      },
+      {
+        'entry-number': 46,
+        'entry-timestamp': '2018-02-23T12:40:56Z',
+        'key': 'qualification-type',
+        'blob-hash': 'sha-256:7f7425463aa0715218af554dd190543fe8dff484f047af27a99e8cb111a15287'
+      },
+      {
+        'entry-number': 47,
+        'entry-timestamp': '2018-02-28T09:32:23Z',
+        'key': 'government-domain',
+        'blob-hash': 'sha-256:83917e94b6cf1786fb892f58638e5e7ebe613b2497db35d6383738de3dbbe53e'
+      },
+      {
+        'entry-number': 48,
+        'entry-timestamp': '2018-06-07T13:41:49Z',
+        'key': 'allergen',
+        'blob-hash': 'sha-256:1226291b13e2fed353e4fb513f3e1ee6ebb537c015e038a4abf67ba1cf7a5529'
+      },
+      {
+        'entry-number': 49,
+        'entry-timestamp': '2018-06-07T13:43:14Z',
+        'key': 'country',
+        'blob-hash': 'sha-256:7634963adce403e5bd3abdf3d22b5006225c38c62babb5b39bf1cccbc1159e56'
+      },
+      {
+        'entry-number': 50,
+        'entry-timestamp': '2018-06-07T13:44:01Z',
+        'key': 'government-domain',
+        'blob-hash': 'sha-256:857cbadaa4dc58079c2483ff9f228d82accec5c03e20a593a77b852f5860aa03'
+      },
+      {
+        'entry-number': 51,
+        'entry-timestamp': '2018-06-07T13:44:37Z',
+        'key': 'government-organisation',
+        'blob-hash': 'sha-256:3585d7a211d4f07c3a7411146fbca61491efb3834c4796b85219a4d6f568ce13'
+      },
+      {
+        'entry-number': 52,
+        'entry-timestamp': '2018-06-07T13:45:04Z',
+        'key': 'government-service',
+        'blob-hash': 'sha-256:c46afc3383e6f6a3864b4ac9a465de5f3e67d12e320cd5b0a7c238bb8bef396e'
+      },
+      {
+        'entry-number': 53,
+        'entry-timestamp': '2018-06-07T13:45:29Z',
+        'key': 'jobcentre-district',
+        'blob-hash': 'sha-256:db01e6173e8c63969cdee9561c6b101b41b6372072031d3e4a6875a5c8dc3ca4'
+      },
+      {
+        'entry-number': 54,
+        'entry-timestamp': '2018-06-07T13:45:46Z',
+        'key': 'jobcentre-group',
+        'blob-hash': 'sha-256:7f9c3d2ede90d35326b01fab652a97c38d3c7df1a430e5029fdc34f38692fe7e'
+      },
+      {
+        'entry-number': 55,
+        'entry-timestamp': '2018-06-07T13:46:10Z',
+        'key': 'qualification-type',
+        'blob-hash': 'sha-256:04a8fe7ac103fc9f3854694e8ca47eef44120cccebd70d99ef57750c6d5721fd'
+      },
+      {
+        'entry-number': 56,
+        'entry-timestamp': '2018-06-07T13:46:32Z',
+        'key': 'territory',
+        'blob-hash': 'sha-256:ee58ed4b749ab5375cc1b69e356d04d669f6f5eb4c6578c738cec0ddcdd38da2'
+      },
+      {
+        'entry-number': 57,
+        'entry-timestamp': '2018-06-21T13:01:07Z',
+        'key': 'approved-open-standard-guidance',
+        'blob-hash': 'sha-256:55b86a451ed89255a8314b1fd591ddf806ba1bb616cf35d2671ba025860b8a63'
+      },
+      {
+        'entry-number': 58,
+        'entry-timestamp': '2018-06-21T13:01:36Z',
+        'key': 'approved-open-standard',
+        'blob-hash': 'sha-256:19e7a6f0ae51bda4942efe894076043ef6250b255e8b58f368929daded121bd5'
+      },
+      {
+        'entry-number': 59,
+        'entry-timestamp': '2018-07-03T09:54:09Z',
+        'key': 'ddat-profession-capability-framework-job-family',
+        'blob-hash': 'sha-256:dc049ecff16c9beabf3fd6ed974d7d0b456e0129ab3c24c5218044121d88205f'
+      },
+      {
+        'entry-number': 60,
+        'entry-timestamp': '2018-07-03T09:54:41Z',
+        'key': 'ddat-profession-capability-framework-level',
+        'blob-hash': 'sha-256:3998b88eeb2793080906582e8df95a8a4366a40bce62d642833ca20e41181227'
+      },
+      {
+        'entry-number': 61,
+        'entry-timestamp': '2018-07-03T09:54:59Z',
+        'key': 'ddat-profession-capability-framework-role-level',
+        'blob-hash': 'sha-256:6aeebe1d6aa69ae0861fbd02f31a15a91771e895cc7ddc9cbd31a8ccddd02278'
+      },
+      {
+        'entry-number': 62,
+        'entry-timestamp': '2018-07-03T09:55:17Z',
+        'key': 'ddat-profession-capability-framework-role',
+        'blob-hash': 'sha-256:954ab2d17a1184bc8cd33777f3e030b7ab8ccb2e06465e360253a1e56e1cb213'
+      },
+      {
+        'entry-number': 63,
+        'entry-timestamp': '2018-07-03T09:55:37Z',
+        'key': 'ddat-profession-capability-framework-skill-level',
+        'blob-hash': 'sha-256:d791895f1e42cf233698eee2999a8ffb992a0daa8fc486b940d0c8c0b1737ebd'
+      },
+      {
+        'entry-number': 64,
+        'entry-timestamp': '2018-07-03T09:56:00Z',
+        'key': 'ddat-profession-capability-framework-skill-type',
+        'blob-hash': 'sha-256:c86cd9271ee4acdbf2a059a15baf0a941929e34a1fbdd69e79148f0b39fc8b68'
+      },
+      {
+        'entry-number': 65,
+        'entry-timestamp': '2018-07-03T09:56:30Z',
+        'key': 'ddat-profession-capability-framework-skill',
+        'blob-hash': 'sha-256:21217eff5f7fd05c962c178d6f40a19ea7a4c204c394d689d2d302f12cb8caba'
+      },
+      {
+        'entry-number': 66,
+        'entry-timestamp': '2018-07-03T09:56:50Z',
+        'key': 'ddat-profession-capability-framework',
+        'blob-hash': 'sha-256:6d017c65d18c5cb46e1d6514932449c75b24038df9cc7a745a8999a106d92ffe'
+      },
+      {
+        'entry-number': 67,
+        'entry-timestamp': '2018-11-01T13:52:12Z',
+        'key': 'information-sharing-agreement-0001',
+        'blob-hash': 'sha-256:bc5689759f0ccb6f21d28ec11546d63e64f3938c33158ee416d204e19985e739'
+      },
+      {
+        'entry-number': 68,
+        'entry-timestamp': '2018-11-01T13:53:31Z',
+        'key': 'information-sharing-agreement-powers-and-objectives-0001',
+        'blob-hash': 'sha-256:8086f389ab3aa0d14ae45cb609a56719117c3510644bf0c0777c6493f6cdfadb'
+      },
+      {
+        'entry-number': 69,
+        'entry-timestamp': '2018-11-01T13:54:08Z',
+        'key': 'information-sharing-agreement-specified-person-0001',
+        'blob-hash': 'sha-256:4592393079746eb0b85095d352ab1f010a2aeaeeb344e453c077f1eb6cfbe339'
+      },
+      {
+        'entry-number': 70,
+        'entry-timestamp': '2018-12-12T17:04:10Z',
+        'key': 'further-education-college-region-uk',
+        'blob-hash': 'sha-256:58f9b4596162107131cbaaeab94d8a69791fd1aa114d1fd7f375c667134bece8'
+      },
+      {
+        'entry-number': 71,
+        'entry-timestamp': '2018-12-12T17:06:25Z',
+        'key': 'further-education-college-uk',
+        'blob-hash': 'sha-256:6b92c47fa4282cf03a2a52b3ad2b698725afca0199a76964314adccdf942b8c1'
+      },
+      {
+        'entry-number': 72,
+        'entry-timestamp': '2018-12-13T16:19:41Z',
+        'key': 'school-type-eng',
+        'blob-hash': 'sha-256:9943eef750932c75a7cf0ee868dfc2b963f9fc348436244a611055f97cfd7b4f'
+      }
+    ],
+    'next/blobs': [
+      {
+        'phase': 'beta',
+        'registry': 'cabinet-office',
+        'text': 'Registers maintained by the UK government',
+        'fields': [
+          'register',
+          'text',
+          'registry',
+          'phase',
+          'copyright',
+          'fields'
+        ],
+        'register': 'register',
+        '_id': 'sha-256:4b95c3bce8a616a2bfcb3d9193828da005bbb69dea1c997cc5b82d167d2ca322'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'cabinet-office',
+        'text': 'Registers maintained by HM Government',
+        'fields': [
+          'register',
+          'text',
+          'registry',
+          'phase',
+          'copyright',
+          'fields'
+        ],
+        'register': 'register',
+        '_id': 'sha-256:e8bd8b3a8994f47be1d57cb283053d6dc96e121007110a6e461ae3fee2870a13'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'foreign-commonwealth-office',
+        'text': 'British English-language names and descriptive terms for countries',
+        'fields': [
+          'country',
+          'name',
+          'official-name',
+          'citizen-names',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'country',
+        '_id': 'sha-256:565f9321785c2cd8543ee262c5331ba84d9a454bc8c45c662c7a17afa2c0b942'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'cabinet-office',
+        'text': 'Datatypes constraining values used by register fields and idenitifying ways in which it may be encoded a representation',
+        'fields': [
+          'datatype',
+          'phase',
+          'text'
+        ],
+        'register': 'datatype',
+        '_id': 'sha-256:03e6b56cdec46ebab847686b44c08e1189194dc88ceeef0b79623e1ee13cb95a'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'cabinet-office',
+        'text': 'Field names which may appear in a register',
+        'fields': [
+          'field',
+          'datatype',
+          'phase',
+          'register',
+          'cardinality',
+          'text'
+        ],
+        'register': 'field',
+        '_id': 'sha-256:da939f5b786ed6850dd6d5ea90573d0c9775042cd390d6d9150c958e362834b8'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Types of local government organisations in the United Kingdom',
+        'fields': [
+          'local-authority-type',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-type',
+        '_id': 'sha-256:19915f7d3322d236cad2b264485bfb7555608d35abab8309533c07fe10e6914f'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-communities-and-local-government',
+        'text': 'Local authorities in England',
+        'fields': [
+          'local-authority-eng',
+          'local-authority-type',
+          'name',
+          'official-name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-eng',
+        '_id': 'sha-256:4f0788db532e2292ccfe9e8298c8a022348ee0fc15052dc6936d18e25a14e811'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'foreign-commonwealth-office',
+        'text': 'British English-language names and descriptive terms for political, administrative and geographical entities that aren’t recognised as countries',
+        'fields': [
+          'territory',
+          'name',
+          'official-name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'territory',
+        '_id': 'sha-256:8b27e52f67cbf3e0cd744c090915eb4b50c88b0bcba9432f53958c09dfe21265'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'foreign-commonwealth-office',
+        'text': 'British English-language names and descriptive terms for political, administrative and geographical entities that aren’t recognised as countries by the UK',
+        'fields': [
+          'territory',
+          'name',
+          'official-name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'territory',
+        '_id': 'sha-256:5137b714aa7e58085320136b5029783fa781fa78bfb3636200af29691dc9b0e5'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-communities-and-local-government',
+        'text': 'Types of local government organisations in the United Kingdom',
+        'fields': [
+          'local-authority-type',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-type',
+        '_id': 'sha-256:ae9141950c1384d0b67e654d1ca54aedd8c9fec228f53abeaebed2058ce878e0'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-environment-food-rural-affairs',
+        'text': 'A register of internal drainage boards in England',
+        'fields': [
+          'internal-drainage-board',
+          'name',
+          'legislation',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'internal-drainage-board',
+        '_id': 'sha-256:a95652224bd8a23667c1eaafea0d0857f9b7e21d7d2c798e426b8f726ed028dc'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Government department, agency or teams that exist on GOV.UK',
+        'fields': [
+          'government-organisation',
+          'name',
+          'website',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'government-organisation',
+        '_id': 'sha-256:268bdaea7d3490557c0d55be544f0d864032d7ad81ca1004b97df16d629dac2d'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Government services that have a government service domain',
+        'fields': [
+          'government-service',
+          'hostname',
+          'government-organisation',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'government-service',
+        '_id': 'sha-256:789a70a4b1ca04df3a92059ad33b9996d049cd2eaceffcd08f8afc2d65499627'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'hm-passport-office',
+        'text': 'Registration districts in England and Wales, defined for the purposes of the Registration Acts',
+        'fields': [
+          'registration-district',
+          'name',
+          'name-cy',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'registration-district',
+        '_id': 'sha-256:efd572c7278044ac427704eb18a9628bfd92bd3b97a88f0b5c1515e29f97576a'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'ministry-of-justice',
+        'text': 'A register of the prison estate in England and Wales as defined by HM Prison and Probation Service',
+        'fields': [
+          'prison-estate',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'prison-estate',
+        '_id': 'sha-256:44d87636a25dc28e8276d0ba95092469c2f282f823e36bef4df1e21d2b4ffdff'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'hm-passport-office',
+        'text': 'Registration districts in England and Wales, defined for the purposes of the Civil Registrations Acts',
+        'fields': [
+          'registration-district',
+          'name',
+          'name-cy',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'registration-district',
+        '_id': 'sha-256:262aad99491d37e0d1e9ea3b6f4d3b946c08b55f1112faddc5e75345a8563c56'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'the-scottish-government',
+        'text': 'Local authorities in Scotland',
+        'fields': [
+          'local-authority-sct',
+          'local-authority-type',
+          'name',
+          'official-name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-sct',
+        '_id': 'sha-256:e4f43a873da83dfc90485eb784fe41436780be988fb4167f73f992f99e909ec2'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'welsh-government',
+        'text': 'Principal local authorities in Wales',
+        'fields': [
+          'principal-local-authority',
+          'name',
+          'name-cy',
+          'official-name',
+          'official-name-cy',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'principal-local-authority',
+        '_id': 'sha-256:6a94a8165a781f461a24febbd1a0da2c3d688348fd412be8bc10d3b807a44c5b'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'cabinet-office',
+        'text': 'Forms that the data in a register field can take',
+        'fields': [
+          'datatype',
+          'phase',
+          'text'
+        ],
+        'register': 'datatype',
+        '_id': 'sha-256:6a7d233e3e6a14cc7f970e069841557f66e112f4279d37d7fdcd45c5139dcaf1'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-environment-food-rural-affairs',
+        'text': 'Public bodies in England that manage drainage systems',
+        'fields': [
+          'internal-drainage-board',
+          'name',
+          'legislation',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'internal-drainage-board',
+        '_id': 'sha-256:9ac0814a3e14ab23d06ddf97723423d97d4dab07c655c828e7e756cd2fe657f4'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-communities-and-local-government',
+        'text': 'Types of local government organisations in the UK',
+        'fields': [
+          'local-authority-type',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-type',
+        '_id': 'sha-256:ae5d08f86cbe99f606fee1c2107e793876fcf7206f03aa16802db2136e28f366'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'ministry-of-justice',
+        'text': 'A register of the prison estates in England and Wales as defined by HM Prison and Probation Service',
+        'fields': [
+          'prison-estate',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'prison-estate',
+        '_id': 'sha-256:35b6f1b940ceb8e4e0406c428f2afcee16667d0977ff6f8c38de3d8d2c335f95'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'hm-passport-office',
+        'text': 'Districts in England and Wales responsible for recording births, marriages, deaths or civil partnerships for the purpose of registration acts',
+        'fields': [
+          'registration-district',
+          'name',
+          'name-cy',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'registration-district',
+        '_id': 'sha-256:4d45d7cbaecf21087e5e1d8ec4f9a0f1e31f3caa06daac39cd3eafe4ba230e39'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'cabinet-office',
+        'text': 'Government domains that appear on GOV.UK',
+        'fields': [
+          'government-domain',
+          'hostname',
+          'organisation',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'government-domain',
+        '_id': 'sha-256:857cbadaa4dc58079c2483ff9f228d82accec5c03e20a593a77b852f5860aa03'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'office-for-national-statistics',
+        'text': 'Statistical geography data for principal local authorities in Wales',
+        'fields': [
+          'statistical-geography-unitary-authority-wls',
+          'principal-local-authority',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-unitary-authority-wls',
+        '_id': 'sha-256:1649e7cd7a328f4e76fe6500d374f19f2e1ee4d61a9b91d3a2569af3a7791248'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'office-for-national-statistics',
+        'text': 'Geographies that are used in compiling official statistics',
+        'fields': [
+          'statistical-geography',
+          'name',
+          'area',
+          'organisation',
+          'register',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography',
+        '_id': 'sha-256:95084028bc97816b75b62db26bd1d51c3197de62efdf59b58855515c1f1cd777'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'ministry-of-justice',
+        'text': 'Prison estates in England and Wales as defined by HM Prison and Probation Service',
+        'fields': [
+          'prison-estate',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'prison-estate',
+        '_id': 'sha-256:1cb127ba64143d28aed2b70d14dad0b6e20d157d020fc18839af2900f5e4194b'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-communities-northern-ireland',
+        'text': 'Local authorities in Northern Ireland',
+        'fields': [
+          'local-authority-nir',
+          'local-authority-type',
+          'name',
+          'website',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-nir',
+        '_id': 'sha-256:d7cbae1d5ea71367182b741aa4029b7f47f63e1a2b54703cdadb6576dff9ebd0'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'office-for-national-statistics',
+        'text': 'Statistical geography data for counties in England',
+        'fields': [
+          'statistical-geography-county-eng',
+          'local-authority-eng',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-county-eng',
+        '_id': 'sha-256:34928f1065c69f6b453a494e4e4673be30ef58e7313a09352f81904300268a4a'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'office-for-national-statistics',
+        'text': 'Statistical geography data for London boroughs in England',
+        'fields': [
+          'statistical-geography-london-borough-eng',
+          'local-authority-eng',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-london-borough-eng',
+        '_id': 'sha-256:66967eb8dc65ea566dfffcd1cfed5fc0d133f2a9e02ba6f36b09e644ba461a96'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'office-for-national-statistics',
+        'text': 'Statistical geography data for metropolitan councils in England',
+        'fields': [
+          'statistical-geography-metropolitan-district-eng',
+          'local-authority-eng',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-metropolitan-district-eng',
+        '_id': 'sha-256:226194d2a5af7da3bc6812cb560ece433a7b91c5f6c79a75a9acca30d74b388c'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'office-for-national-statistics',
+        'text': 'Statistical geography data for registration districts in England',
+        'fields': [
+          'statistical-geography-registration-district-eng',
+          'registration-district',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-registration-district-eng',
+        '_id': 'sha-256:75018bd326d7bd6839f6a5274e64ece47bb60816b7180c163f86d1998171a953'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'office-for-national-statistics',
+        'text': 'Statistical geography data for registration districts in Wales',
+        'fields': [
+          'statistical-geography-registration-district-wls',
+          'registration-district',
+          'name',
+          'name-cy',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-registration-district-wls',
+        '_id': 'sha-256:f45870303e8b513d91ed07fb81f918383b8f9a17e7d485d0a4c00bbf014bbece'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'office-for-national-statistics',
+        'text': 'Statistical geography data for non-metropolitan councils in England',
+        'fields': [
+          'statistical-geography-non-metropolitan-district-eng',
+          'local-authority-eng',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-non-metropolitan-district-eng',
+        '_id': 'sha-256:dd199bbe96e68d7a219ca84056164ccd0b5a814cfcaea2163307511ea7b9686b'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'office-for-national-statistics',
+        'text': 'Statistical geography data for a unitary authority in England',
+        'fields': [
+          'statistical-geography-unitary-authority-eng',
+          'local-authority-eng',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-unitary-authority-eng',
+        '_id': 'sha-256:fff32a5756b5a1159fe099cf9db4dcff7f7c965a04fd8677cb13c2580073c735'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'food-standards-agency',
+        'text': 'Allergens referenced in Food Standards Agency food safety alerts',
+        'fields': [
+          'allergen',
+          'name',
+          'allergen-group',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'allergen',
+        '_id': 'sha-256:ee54eb7eb0db89f695440e3f67d6b349eb6df891837c2ca98915ffa0383f5dff'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'office-for-national-statistics',
+        'text': 'Statistical geography data for local government districts in Northern Ireland',
+        'fields': [
+          'statistical-geography-local-government-district-nir',
+          'local-authority-nir',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'statistical-geography-local-government-district-nir',
+        '_id': 'sha-256:36840b2f05f0eae63ed8d389bd7b6985883a33f94aed28e85f295fe2808f3156'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-work-pensions',
+        'text': 'Jobcentre offices in England, Scotland and Wales',
+        'fields': [
+          'jobcentre',
+          'name',
+          'jobcentre-district',
+          'address',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'jobcentre',
+        '_id': 'sha-256:16d92db6a458b523bfacd2245b596f12a22782980ea266e039c094c14cc5ae6f'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-work-pensions',
+        'text': 'Districts of jobcentre offices',
+        'fields': [
+          'jobcentre-district',
+          'name',
+          'jobcentre-group',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'jobcentre-district',
+        '_id': 'sha-256:7c89f9f4e46e34502b1a1c1df3f6479101114a2af316affc64c7532e1af100e4'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-work-pensions',
+        'text': 'Groups of jobcentre offices',
+        'fields': [
+          'jobcentre-group',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'jobcentre-group',
+        '_id': 'sha-256:731ad531996a5ef7e99f2c208843a27711412d3cba0fb007c663077366f7619b'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'ministry-of-housing-communities-and-local-government',
+        'text': 'Types of local government organisations in the UK',
+        'fields': [
+          'local-authority-type',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-type',
+        '_id': 'sha-256:f5e71ac52548df5270526ca97c870cdf4bc76502d33b2671d3d9528c305075e7'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'ministry-of-housing-communities-and-local-government',
+        'text': 'Local authorities in England',
+        'fields': [
+          'local-authority-eng',
+          'local-authority-type',
+          'name',
+          'official-name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'local-authority-eng',
+        '_id': 'sha-256:7b2492ee43b1e0c054b9bc0cadcd138b4433d1cf953293df961be9eab04669f3'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'ofqual',
+        'text': 'Assessment methods of qualifications regulated by Ofqual',
+        'fields': [
+          'qualification-assessment-method',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'qualification-assessment-method',
+        '_id': 'sha-256:0106fb5cc2e0881f746811d1bc16e0e5539c21dd3935c27f8d3b6fdaefb24fee'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'ofqual',
+        'text': 'Levels of qualifications regulated by Ofqual',
+        'fields': [
+          'qualification-level',
+          'name',
+          'qualification-sub-level',
+          'european-qualification-framework-level',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'qualification-level',
+        '_id': 'sha-256:8b654106f5187772e55edc32337c18e0e74a939947ee93255d698acf93b4873c'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'ofqual',
+        'text': 'Subjects of qualifications regulated by Ofqual',
+        'fields': [
+          'qualification-sector-subject-area',
+          'parent-qualification-sector-subject-area',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'qualification-sector-subject-area',
+        '_id': 'sha-256:5b312eb573c1a83defc3bd3c907925c0f28db59f40d0969fc30edb565787beff'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'ofqual',
+        'text': 'Types of qualification regulated by Ofqual',
+        'fields': [
+          'qualification-type',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'qualification-type',
+        '_id': 'sha-256:7f7425463aa0715218af554dd190543fe8dff484f047af27a99e8cb111a15287'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'cabinet-office',
+        'text': 'Government domains that appear on the gov.uk domain',
+        'fields': [
+          'government-domain',
+          'hostname',
+          'organisation',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'government-domain',
+        '_id': 'sha-256:83917e94b6cf1786fb892f58638e5e7ebe613b2497db35d6383738de3dbbe53e'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'food-standards-agency',
+        'text': 'Food allergens as recognised by the Food Standards Agency',
+        'fields': [
+          'allergen',
+          'name',
+          'allergen-group',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'allergen',
+        '_id': 'sha-256:1226291b13e2fed353e4fb513f3e1ee6ebb537c015e038a4abf67ba1cf7a5529'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'foreign-commonwealth-office',
+        'text': 'British English names and descriptive terms for countries as recognised by the UK government',
+        'fields': [
+          'country',
+          'name',
+          'official-name',
+          'citizen-names',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'country',
+        '_id': 'sha-256:7634963adce403e5bd3abdf3d22b5006225c38c62babb5b39bf1cccbc1159e56'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Government departments, agencies or teams that exist on GOV.UK',
+        'fields': [
+          'government-organisation',
+          'name',
+          'website',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'government-organisation',
+        '_id': 'sha-256:3585d7a211d4f07c3a7411146fbca61491efb3834c4796b85219a4d6f568ce13'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Government services that have a government service domain on GOV.UK',
+        'fields': [
+          'government-service',
+          'hostname',
+          'government-organisation',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'government-service',
+        '_id': 'sha-256:c46afc3383e6f6a3864b4ac9a465de5f3e67d12e320cd5b0a7c238bb8bef396e'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-work-pensions',
+        'text': 'Districts of jobcentre offices in England, Scotland and Wales',
+        'fields': [
+          'jobcentre-district',
+          'name',
+          'jobcentre-group',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'jobcentre-district',
+        '_id': 'sha-256:db01e6173e8c63969cdee9561c6b101b41b6372072031d3e4a6875a5c8dc3ca4'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-work-pensions',
+        'text': 'Groups of jobcentre offices in England, Scotland and Wales',
+        'fields': [
+          'jobcentre-group',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'jobcentre-group',
+        '_id': 'sha-256:7f9c3d2ede90d35326b01fab652a97c38d3c7df1a430e5029fdc34f38692fe7e'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'ofqual',
+        'text': 'Types of qualifications regulated by Ofqual',
+        'fields': [
+          'qualification-type',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'qualification-type',
+        '_id': 'sha-256:04a8fe7ac103fc9f3854694e8ca47eef44120cccebd70d99ef57750c6d5721fd'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'foreign-commonwealth-office',
+        'text': 'British English names and descriptive terms for political, administrative and geographical entities that are not recognised as countries by the UK government',
+        'fields': [
+          'territory',
+          'name',
+          'official-name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'territory',
+        '_id': 'sha-256:ee58ed4b749ab5375cc1b69e356d04d669f6f5eb4c6578c738cec0ddcdd38da2'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Guidance defining open standards approved for government technology',
+        'fields': [
+          'approved-open-standard-guidance',
+          'name',
+          'approved-open-standards',
+          'website',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'approved-open-standard-guidance',
+        '_id': 'sha-256:55b86a451ed89255a8314b1fd591ddf806ba1bb616cf35d2671ba025860b8a63'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Open standards approved for use in government technology',
+        'fields': [
+          'approved-open-standard',
+          'name',
+          'short-name',
+          'website',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'approved-open-standard',
+        '_id': 'sha-256:19e7a6f0ae51bda4942efe894076043ef6250b255e8b58f368929daded121bd5'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Job families for use in the Digital, Data and Technology Profession Capability Framework',
+        'fields': [
+          'ddat-profession-capability-framework-job-family',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-job-family',
+        '_id': 'sha-256:dc049ecff16c9beabf3fd6ed974d7d0b456e0129ab3c24c5218044121d88205f'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Levels of competency for each Digital, Data and Technology Profession Capability Framework skill',
+        'fields': [
+          'ddat-profession-capability-framework-level',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-level',
+        '_id': 'sha-256:3998b88eeb2793080906582e8df95a8a4366a40bce62d642833ca20e41181227'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Levels associated with each role within the Digital, Data and Technology Profession Capability Framework',
+        'fields': [
+          'ddat-profession-capability-framework-role-level',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-role-level',
+        '_id': 'sha-256:6aeebe1d6aa69ae0861fbd02f31a15a91771e895cc7ddc9cbd31a8ccddd02278'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Roles defined for use in the Digital, Data and Technology Profession Capability Framework',
+        'fields': [
+          'ddat-profession-capability-framework-role',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-role',
+        '_id': 'sha-256:954ab2d17a1184bc8cd33777f3e030b7ab8ccb2e06465e360253a1e56e1cb213'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'The skills, levels, and appropriate descriptions used in the Digital Data and Technology Profession Capability Framework',
+        'fields': [
+          'ddat-profession-capability-framework-skill-level',
+          'profession-capability-framework-skill',
+          'profession-capability-framework-level',
+          'description',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-skill-level',
+        '_id': 'sha-256:d791895f1e42cf233698eee2999a8ffb992a0daa8fc486b940d0c8c0b1737ebd'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Types of skill for use in the Digital, Data and Technology Profession Capability Framework',
+        'fields': [
+          'ddat-profession-capability-framework-skill-type',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-skill-type',
+        '_id': 'sha-256:c86cd9271ee4acdbf2a059a15baf0a941929e34a1fbdd69e79148f0b39fc8b68'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'Skills for use in the Digital, Data and Technology Profession Capability Framework',
+        'fields': [
+          'ddat-profession-capability-framework-skill',
+          'name',
+          'description',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework-skill',
+        '_id': 'sha-256:21217eff5f7fd05c962c178d6f40a19ea7a4c204c394d689d2d302f12cb8caba'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'government-digital-service',
+        'text': 'The roles in the Digital, Data and Technology Profession Capability Framework and detailed descriptions of the types and level of skills expected for each role',
+        'fields': [
+          'ddat-profession-capability-framework',
+          'profession-capability-framework-skill-type',
+          'profession-capability-framework-job-family',
+          'profession-capability-framework-role',
+          'profession-capability-framework-role-level',
+          'profession-capability-framework-skill',
+          'profession-capability-framework-level',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'ddat-profession-capability-framework',
+        '_id': 'sha-256:6d017c65d18c5cb46e1d6514932449c75b24038df9cc7a745a8999a106d92ffe'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-digital-culture-media-sport',
+        'text': 'Information sharing agreements under the public service delivery, debt, fraud and civil registration provisions within the Digital Economy Act 2017',
+        'fields': [
+          'information-sharing-agreement-0001',
+          'name',
+          'purpose',
+          'information-sharing-benefits',
+          'legal-power-disclosure',
+          'disclosed-information',
+          'controllers',
+          'controller-names',
+          'information-sharing-method',
+          'processors',
+          'processor-names',
+          'retention-period',
+          'start-date',
+          'end-date',
+          'review-date',
+          'contact',
+          'areas',
+          'area-names'
+        ],
+        'register': 'information-sharing-agreement-0001',
+        '_id': 'sha-256:bc5689759f0ccb6f21d28ec11546d63e64f3938c33158ee416d204e19985e739'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-digital-culture-media-sport',
+        'text': 'List of information sharing powers and objectives available under chapters 1, 2, 3 and 4 of Part 5 of the Digital Economy Act 2017',
+        'fields': [
+          'information-sharing-agreement-powers-and-objectives-0001',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'information-sharing-agreement-powers-and-objectives-0001',
+        '_id': 'sha-256:8086f389ab3aa0d14ae45cb609a56719117c3510644bf0c0777c6493f6cdfadb'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-digital-culture-media-sport',
+        'text': 'Specified persons for the information sharing agreements under the public service delivery, debt, fraud and civil registration provisions within the Digital Economy Act 2017',
+        'fields': [
+          'information-sharing-agreement-specified-person-0001',
+          'name',
+          'relevant-powers',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'information-sharing-agreement-specified-person-0001',
+        '_id': 'sha-256:4592393079746eb0b85095d352ab1f010a2aeaeeb344e453c077f1eb6cfbe339'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-international-trade',
+        'text': 'A register of the regions in the United Kingdom, where a further education college is situated',
+        'fields': [
+          'further-education-college-region-uk',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'further-education-college-region-uk',
+        '_id': 'sha-256:58f9b4596162107131cbaaeab94d8a69791fd1aa114d1fd7f375c667134bece8'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-international-trade',
+        'text': 'A register of further education colleges across the United Kingdom',
+        'fields': [
+          'further-education-college-uk',
+          'name',
+          'region',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'further-education-college-uk',
+        '_id': 'sha-256:6b92c47fa4282cf03a2a52b3ad2b698725afca0199a76964314adccdf942b8c1'
+      },
+      {
+        'phase': 'beta',
+        'registry': 'department-for-education',
+        'text': 'Types of school in England',
+        'fields': [
+          'school-type-eng',
+          'name',
+          'start-date',
+          'end-date'
+        ],
+        'register': 'school-type-eng',
+        '_id': 'sha-256:9943eef750932c75a7cf0ee868dfc2b963f9fc348436244a611055f97cfd7b4f'
+      }
+    ]
   }
 }


### PR DESCRIPTION
Hi @nickcolley 

The registers team are about to make a bunch of breaking changes to the API, and we're handling this by adding a version number to the URL. The new version is not properly released yet, but a preview is available at `https://country.register.gov.uk/next/`.

This PR is a first stab at adding support for querying different API versions to the library. It includes a new endpoint for fetching all the items (now called blobs).

I also had a go at implementing a different way of paginating through collections. In my opinion, you should ignore what the official documentation says about using query parameters for pagination and instead follow the [the registers spec](https://spec.openregister.org/v2/rest-api#pagination), which says to rely on the `Link` header for pagination.

The downside of relying on query parameters is that they're specific to our particular implementation of registers, the parameters are inconsistent across collections, and for `/blobs` the `start` values are hashes, rather than an sequence of numbers, so users can't calculate where the next page starts without the link.

For this work though, collection methods would need to return some kind of object instead of arrays of data. In this PR I implemented this for the blobs method.

There's some more details of the upcoming API changes [here](https://docs.registers.service.gov.uk/api_reference/version-history/#changes), although the guide is not complete yet.